### PR TITLE
Reduce size of wheels by stripping debug information

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,12 +222,15 @@ jobs:
             PYTHON_ISAL_BUILD_CACHE=True
             # This is in the docker container. So probably a '/tmp' will be available
             PYTHON_ISAL_BUILD_CACHE_FILE=/tmp/build_cache
+            CFLAGS=-g0
           CIBW_ENVIRONMENT_WINDOWS: >-
             PYTHON_ISAL_BUILD_CACHE=True
             PYTHON_ISAL_BUILD_CACHE_FILE=${{ runner.temp }}\build_cache
+            CFLAGS=-g0
           CIBW_ENVIRONMENT_MACOS: >-
             PYTHON_ISAL_BUILD_CACHE=True
             PYTHON_ISAL_BUILD_CACHE_FILE=${{ runner.temp }}/build_cache
+            CFLAGS=-g0
       - name: Build sdist
         if: ${{runner.os == 'Linux' && matrix.cibw_archs_linux == 'x86_64'}}
         run: |


### PR DESCRIPTION
According to https://github.com/marcelm/dnaio/pull/47, it seems you like smaller wheels, so I’d like to suggest using `CFLAGS=-g0` to reduce their size.

See https://github.com/pypa/cibuildwheel/issues/331

I’m using this option already in dnaio and Cutadapt and it works well (wheel size is now ~150 kB instead of ~500 kB). I wasn’t able to test this locally for python-isal, so the savings may be smaller, but running `strip` (which I assume does something similar as `-g0` would do) on the uncompressed `.so` files on the wheels available from PyPI reduces their size by 90%.

It is possible that the option is not necessary or has no effect on Windows and/or macOS; I just added it for completeness.

### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)
