### PR TITLE
Expose READ/WRITE gzip consts (in addition to existing FTEXT, FEXTRA, etc)

### DIFF
--- a/src/isal/igzip.py
+++ b/src/isal/igzip.py
@@ -54,6 +54,7 @@ _COMPRESS_LEVEL_BEST = isal_zlib.ISAL_BEST_COMPRESSION
 READ_BUFFER_SIZE = 128 * 1024
 
 FTEXT, FHCRC, FEXTRA, FNAME, FCOMMENT = 1, 2, 4, 8, 16
+READ, WRITE = 1, 2
 
 try:
     BadGzipFile = gzip.BadGzipFile  # type: ignore
@@ -158,13 +159,13 @@ class IGzipFile(gzip.GzipFile):
                     isal_zlib.ISAL_BEST_SPEED, isal_zlib.ISAL_BEST_COMPRESSION
                 ))
         super().__init__(filename, mode, compresslevel, fileobj, mtime)
-        if self.mode == gzip.WRITE:
+        if self.mode == WRITE:
             self.compress = isal_zlib.compressobj(compresslevel,
                                                   isal_zlib.DEFLATED,
                                                   -isal_zlib.MAX_WBITS,
                                                   isal_zlib.DEF_MEM_LEVEL,
                                                   0)
-        if self.mode == gzip.READ:
+        if self.mode == READ:
             raw = _IGzipReader(self.fileobj)
             self._buffer = io.BufferedReader(raw, buffer_size=READ_BUFFER_SIZE)
 
@@ -197,7 +198,7 @@ class IGzipFile(gzip.GzipFile):
 
     def write(self, data):
         self._check_not_closed()
-        if self.mode != gzip.WRITE:
+        if self.mode != WRITE:
             import errno
             raise OSError(errno.EBADF, "write() on read-only IGzipFile object")
 

--- a/tests/test_gzip_compliance.py
+++ b/tests/test_gzip_compliance.py
@@ -657,6 +657,7 @@ class TestGzip(BaseTest):
         self.assertEqual(gzip.READ, igzip.READ)
         self.assertEqual(gzip.WRITE, igzip.WRITE)
 
+
 class TestOpen(BaseTest):
     def test_binary_modes(self):
         uncompressed = data1 * 50

--- a/tests/test_gzip_compliance.py
+++ b/tests/test_gzip_compliance.py
@@ -646,6 +646,16 @@ class TestGzip(BaseTest):
         with igzip.open(self.filename, "rb") as f:
             f._buffer.raw._fp.prepend()
 
+    def test_public_consts(self):
+        # Confirm that all of the gzip module public consts are
+        # also accessible via igzip, for drop-in compatibility.
+        self.assertEqual(gzip.FCOMMENT, igzip.FCOMMENT)
+        self.assertEqual(gzip.FEXTRA, igzip.FEXTRA)
+        self.assertEqual(gzip.FHCRC, igzip.FHCRC)
+        self.assertEqual(gzip.FNAME, igzip.FNAME)
+        self.assertEqual(gzip.FTEXT, igzip.FTEXT)
+        self.assertEqual(gzip.READ, igzip.READ)
+        self.assertEqual(gzip.WRITE, igzip.WRITE)
 
 class TestOpen(BaseTest):
     def test_binary_modes(self):


### PR DESCRIPTION
Added/exposed the only missing top-level gzip consts, `READ` and `WRITE`, with the expected values. Improves drop-in completeness / replacement behaviour when substituting `gzip` imports with `igzip` imports.

(Note: all of the other public consts are already exposed/available: `FCOMMENT`, `FEXTRA`, `FHCRC`, `FNAME`, `FTEXT`).

Added test coverage to confirm the presence (and expected value) of all of these.