### PR TITLE
Better BGZF format streaming performance.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 1.3.0-dev
+-----------------
++ Gzip headers are now actively checked for a BGZF extra field. If found the
+  block size is taken into account when decompressing. This has further
+  improved bgzf decompression speed by 5% on some files compared to the
+  more generic solution of 1.2.0.
++ Integrated CPython 3.11 code for reading gzip headers. This leads to more
+  commonality between the python-isal code and the upstream gzip.py code.
+  This has enabled the change above. It comes at the cost of a slight increase
+  in overhead at the ``gzip.decompress`` function.
+
 version 1.2.0
 -----------------
 + Bgzip files are now detected and a smaller reading buffer is used to

--- a/src/isal/igzip.py
+++ b/src/isal/igzip.py
@@ -435,6 +435,10 @@ def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=None):
 def decompress(data):
     """Decompress a gzip compressed string in one shot.
     Return the decompressed string.
+
+    This function checks for extra gzip members. Using
+    isal_zlib.decompress(data, wbits=31) is faster in cases where only one
+    gzip member is guaranteed to be present.
     """
     decompressed_members = []
     while True:

--- a/src/isal/igzip.py
+++ b/src/isal/igzip.py
@@ -236,6 +236,71 @@ def detect_bgzip(header: bytes) -> bool:
     )
 
 
+def _read_exact(fp, n):
+    '''Read exactly *n* bytes from `fp`
+
+    This method is required because fp may be unbuffered,
+    i.e. return short reads.
+    '''
+    data = fp.read(n)
+    while len(data) < n:
+        b = fp.read(n - len(data))
+        if not b:
+            raise EOFError("Compressed file ended before the "
+                           "end-of-stream marker was reached")
+        data += b
+    return data
+
+
+def _read_gzip_header(fp):
+    '''Read a gzip header from `fp` and progress to the end of the header.
+
+    Returns last mtime if header was present or None otherwise.
+    '''
+    # Do not use read_exact because a header may not be present. Read twice
+    # since fp might be unbuffered.
+    magic = fp.read(1) + fp.read(1)
+    if magic == b'':
+        return None
+
+    if magic != b'\037\213':
+        raise BadGzipFile('Not a gzipped file (%r)' % magic)
+
+    common_fields = _read_exact(fp, 8)
+    (method, flag, last_mtime) = struct.unpack("<BBIxx", common_fields)
+    if method != 8:
+        raise BadGzipFile('Unknown compression method')
+    header = magic + common_fields
+    if flag & FEXTRA:
+        # Read & discard the extra field, if present
+        encoded_length = _read_exact(fp, 2)
+        extra_len, = struct.unpack("<H", encoded_length)
+        extra_field = _read_exact(fp, extra_len)
+        header = header + encoded_length + extra_field
+    if flag & FNAME:
+        # Read and discard a null-terminated string containing the filename
+        while True:
+            s = _read_exact(fp, 1)
+            header += s
+            if s == b'\000':
+                break
+    if flag & FCOMMENT:
+        # Read and discard a null-terminated string containing a comment
+        while True:
+            s = _read_exact(fp, 1)
+            header += s
+            if s == b'\000':
+                break
+    if flag & FHCRC:
+        header_crc_encoded = _read_exact(fp, 2)
+        header_crc, = struct.unpack("<H", header_crc_encoded)
+        crc = isal_zlib.crc32(header) & 0xFFFF
+        if header_crc != crc:
+            raise BadGzipFile(f"Corrupted gzip header. Checksums do not "
+                              f"match: {crc:04x} != {header_crc:04x}")
+    return last_mtime
+
+
 class _PaddedFile(gzip._PaddedFile):
     # Overwrite _PaddedFile from gzip as its prepend method assumes that
     # the prepended data is always read from its _buffer. Unfortunately in
@@ -275,6 +340,13 @@ class _IGzipReader(gzip._GzipReader):
             # efficiently but this is outside scope for python-isal.
             self._read_buffer_size = 16 * 1024
 
+    def _read_gzip_header(self):
+        last_mtime = _read_gzip_header(self._fp)
+        if last_mtime is None:
+            return False
+        self._last_mtime = last_mtime
+        return True
+
     def read(self, size=-1):
         if size < 0:
             return self.readall()
@@ -300,7 +372,8 @@ class _IGzipReader(gzip._GzipReader):
                 # If the _new_member flag is set, we have to
                 # jump to the next member, if there is one.
                 self._crc = isal_zlib.crc32(b"")
-                self._stream_size = 0  # Decompressed size of unconcatenated stream
+                # Decompressed size of unconcatenated stream
+                self._stream_size = 0
                 if not self._read_gzip_header():
                     self._size = self._pos
                     return b""
@@ -364,52 +437,6 @@ def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=None):
     return header + compressed
 
 
-def _gzip_header_end(data: bytes) -> int:
-    """
-    Find the start of the raw deflate block in a gzip file.
-    :param data: Compressed data that starts with a gzip header.
-    :return: The end of the header / start of the raw deflate block.
-    """
-    eof_error = EOFError("Compressed file ended before the end-of-stream "
-                         "marker was reached")
-    if len(data) < 10:
-        raise eof_error
-    # We are not interested in mtime, xfl and os flags.
-    magic, method, flags = struct.unpack("<HBB", data[:4])
-    if magic != 0x8b1f:
-        raise BadGzipFile(f"Not a gzipped file ({repr(data[:2])})")
-    if method != 8:
-        raise BadGzipFile("Unknown compression method")
-    if not flags:  # Likely when data compressed in memory
-        return 10
-    pos = 10
-    if flags & FEXTRA:
-        if len(data) < pos + 2:
-            raise eof_error
-        xlen, = struct.unpack("<H", data[pos: pos+2])
-        pos += 2 + xlen
-    if flags & FNAME:
-        pos = data.find(b"\x00", pos) + 1
-        # pos will be -1 + 1 when null byte not found.
-        if not pos:
-            raise eof_error
-    if flags & FCOMMENT:
-        pos = data.find(b"\x00", pos) + 1
-        if not pos:
-            raise eof_error
-    if flags & FHCRC:
-        if len(data) < pos + 2:
-            raise eof_error
-        header_crc, = struct.unpack("<H", data[pos: pos+2])
-        # CRC is stored as a 16-bit integer by taking last bits of crc32.
-        crc = isal_zlib.crc32(data[:pos]) & 0xFFFF
-        if header_crc != crc:
-            raise BadGzipFile(f"Corrupted gzip header. Checksums do not "
-                              f"match: {crc:04x} != {header_crc:04x}")
-        pos += 2
-    return pos
-
-
 def decompress(data):
     """Decompress a gzip compressed string in one shot.
     Return the decompressed string.
@@ -418,7 +445,10 @@ def decompress(data):
     while True:
         if not data:  # Empty data returns empty bytestring
             return b"".join(decompressed_members)
-        header_end = _gzip_header_end(data)
+        fp = io.BytesIO(data)
+        if _read_gzip_header(fp) is None:
+            return b"".join(decompressed_members)
+        header_end = fp.tell()
         # Use a zlib raw deflate compressor
         do = isal_zlib.decompressobj(wbits=-isal_zlib.MAX_WBITS)
         # Read all the data except the header

--- a/src/isal/igzip.py
+++ b/src/isal/igzip.py
@@ -270,6 +270,8 @@ def _read_gzip_header(fp):
     (method, flag, last_mtime) = struct.unpack("<BBIxx", common_fields)
     if method != 8:
         raise BadGzipFile('Unknown compression method')
+    if not flag:  # Likely when data compressed in memory
+        return last_mtime
     header = magic + common_fields
     if flag & FEXTRA:
         # Read & discard the extra field, if present

--- a/src/isal/igzip.py
+++ b/src/isal/igzip.py
@@ -299,7 +299,8 @@ class _IGzipReader(gzip._GzipReader):
             if self._new_member:
                 # If the _new_member flag is set, we have to
                 # jump to the next member, if there is one.
-                self._init_read()
+                self._crc = isal_zlib.crc32(b"")
+                self._stream_size = 0  # Decompressed size of unconcatenated stream
                 if not self._read_gzip_header():
                     self._size = self._pos
                     return b""

--- a/tests/test_igzip.py
+++ b/tests/test_igzip.py
@@ -392,8 +392,10 @@ def headers():
 
 
 @pytest.mark.parametrize("header", list(headers()))
-def test_gzip_header_end(header):
-    assert igzip._gzip_header_end(header) == len(header)
+def test_read_gzip_header_position(header):
+    fp = io.BytesIO(header)
+    igzip._read_gzip_header(fp)
+    assert fp.tell() == len(header)
 
 
 def test_header_too_short():


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.rst
- [x] Documentation was updated (if needed)

Integrate CPython's gzip header code which works on streams. 
Adapt for python-isal:
- header corruption check
- Check for BGZF fields in the Extra fields. If found, save the block size and use that to inform the amount that should be read from the next block.

This change was advantageous mainly for bam files:
Before on uncompressed, level 1 and level 5 compressed bams respectively:
```
Benchmark 1: python -m isal.igzip -cd ~/test/nanopore_100000reads.u.bam > /dev/null
  Time (mean ± σ):     613.3 ms ±  25.2 ms    [User: 478.7 ms, System: 134.4 ms]
  Range (min … max):   600.7 ms … 684.3 ms    10 runs
 
Benchmark 1: python -m isal.igzip -cd ~/test/nanopore_100000reads.1.bam > /dev/null
  Time (mean ± σ):      3.003 s ±  0.004 s    [User: 2.901 s, System: 0.101 s]
  Range (min … max):    2.997 s …  3.008 s    10 runs

Benchmark 1: python -m isal.igzip -cd ~/test/nanopore_100000reads.5.bam > /dev/null
  Time (mean ± σ):      3.120 s ±  0.010 s    [User: 3.013 s, System: 0.106 s]
  Range (min … max):    3.105 s …  3.132 s    10 runs
```

After:
```
Benchmark 1: python -m isal.igzip -cd ~/test/nanopore_100000reads.u.bam > /dev/null
  Time (mean ± σ):     448.6 ms ±   8.3 ms    [User: 355.9 ms, System: 92.1 ms]
  Range (min … max):   433.4 ms … 464.0 ms    10 runs

Benchmark 1: python -m isal.igzip -cd ~/test/nanopore_100000reads.1.bam > /dev/null
  Time (mean ± σ):      2.854 s ±  0.014 s    [User: 2.771 s, System: 0.082 s]
  Range (min … max):    2.837 s …  2.876 s    10 runs

Benchmark 1: python -m isal.igzip -cd ~/test/nanopore_100000reads.5.bam > /dev/null
  Time (mean ± σ):      2.943 s ±  0.012 s    [User: 2.866 s, System: 0.076 s]
  Range (min … max):    2.933 s …  2.970 s    10 runs
```

A pretty significant difference proportional to the number of GZIP blocks used. Especially for uncompressed bgzf it is pretty good, which is relevant because samtools view -u outputs uncompressed bgzf rather than raw bam (without bgzf format). So this is pretty useful when piping in streams.

@marcelm FYI, this will be particularly useful for BAM parsing in dnaio. It is also quite an eventful change. I do trust my test suite, but unforeseen bugs may occur. I will keep an eye on the cutadapt issue tracker after releasing this change.

 
