### PR TITLE
Minor refactorings on GzipReader

### DIFF
--- a/src/isal/isal_zlibmodule.c
+++ b/src/isal/isal_zlibmodule.c
@@ -1608,17 +1608,14 @@ GzipReader_read_into_buffer(GzipReader *self, uint8_t *out_buffer, size_t out_bu
                     self->stream_phase = GzipReader_NULL_BYTES;
                 case GzipReader_NULL_BYTES:
                     // There maybe NULL bytes between gzip members
-                    while (current_pos < buffer_end) {
-                        if (*current_pos != 0) {
-                            self->stream_phase = GzipReader_HEADER;
-                            break;
-                        }
+                    while (current_pos < buffer_end && *current_pos == 0) {
                         current_pos += 1;
                     }
-                    if (current_pos >= buffer_end) {
+                    if (current_pos == buffer_end) {
+                        /* Not all NULL bytes may have been read, refresh the buffer.*/
                         break;
                     }
-                    // Continue to prevent refreshing the buffer for each block.
+                    self->stream_phase = GzipReader_HEADER;
                     continue;
                 default:
                     Py_UNREACHABLE();

--- a/src/isal/isal_zlibmodule.c
+++ b/src/isal/isal_zlibmodule.c
@@ -1944,6 +1944,7 @@ static PyTypeObject GzipReader_Type = {
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_dealloc = (destructor)GzipReader_dealloc,
     .tp_new = (newfunc)(GzipReader__new__),
+    .tp_doc = GzipReader__new____doc__,
     .tp_methods = GzipReader_methods,
     .tp_getset = GzipReader_properties,
 };

--- a/src/isal/isal_zlibmodule.c
+++ b/src/isal/isal_zlibmodule.c
@@ -1222,23 +1222,6 @@ isal_zlib_crc32_combine(PyObject *module, PyObject *args) {
 }
 
 
-typedef struct {
-    PyTypeObject *Comptype;
-    PyTypeObject *Decomptype;
-    PyObject *IsalError;
-} isal_zlib_state;
-
-static PyMethodDef IsalZlibMethods[] = {
-    ISAL_ZLIB_ADLER32_METHODDEF,
-    ISAL_ZLIB_CRC32_METHODDEF,
-    ISAL_ZLIB_CRC32_COMBINE_METHODDEF,
-    ISAL_ZLIB_COMPRESS_METHODDEF,
-    ISAL_ZLIB_DECOMPRESS_METHODDEF,
-    ISAL_ZLIB_COMPRESSOBJ_METHODDEF,
-    ISAL_ZLIB_DECOMPRESSOBJ_METHODDEF,
-    {NULL, NULL, 0, NULL}        /* Sentinel */
-};
-
 static PyMethodDef comp_methods[] = {
     ISAL_ZLIB_COMPRESS_COMPRESS_METHODDEF,
     ISAL_ZLIB_COMPRESS_FLUSH_METHODDEF,
@@ -1964,6 +1947,23 @@ PyDoc_STRVAR(isal_zlib_module_documentation,
 "\n"
 "Compressor objects support compress() and flush() methods; decompressor\n"
 "objects support decompress() and flush().");
+
+typedef struct {
+    PyTypeObject *Comptype;
+    PyTypeObject *Decomptype;
+    PyObject *IsalError;
+} isal_zlib_state;
+
+static PyMethodDef IsalZlibMethods[] = {
+    ISAL_ZLIB_ADLER32_METHODDEF,
+    ISAL_ZLIB_CRC32_METHODDEF,
+    ISAL_ZLIB_CRC32_COMBINE_METHODDEF,
+    ISAL_ZLIB_COMPRESS_METHODDEF,
+    ISAL_ZLIB_DECOMPRESS_METHODDEF,
+    ISAL_ZLIB_COMPRESSOBJ_METHODDEF,
+    ISAL_ZLIB_DECOMPRESSOBJ_METHODDEF,
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
 
 static struct PyModuleDef isal_zlib_module = {
     PyModuleDef_HEAD_INIT,

--- a/src/isal/isal_zlibmodule.c
+++ b/src/isal/isal_zlibmodule.c
@@ -254,6 +254,40 @@ isal_zlib_crc32(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyBuffer_Release(&data);
     return return_value;
 }
+
+PyDoc_STRVAR(isal_zlib_crc32_combine__doc__,
+"crc32_combine($module, crc1, crc2, crc2_length /)\n"
+"--\n"
+"\n"
+"Combine crc1 and crc2 into a new crc that is accurate for the combined data \n"
+"blocks that crc1 and crc2 where calculated from.\n"
+"\n"
+"  crc1\n"
+"    the first crc32 checksum\n"
+"  crc2\n"
+"    the second crc32 checksum\n"
+"  crc2_length\n"
+"    the lenght of the data block crc2 was calculated from\n"
+);
+
+
+#define ISAL_ZLIB_CRC32_COMBINE_METHODDEF    \
+    {"crc32_combine", (PyCFunction)(void(*)(void))isal_zlib_crc32_combine, \
+     METH_VARARGS, isal_zlib_crc32_combine__doc__}
+
+static PyObject *
+isal_zlib_crc32_combine(PyObject *module, PyObject *args) {
+    uint32_t crc1 = 0;
+    uint32_t crc2 = 0;
+    Py_ssize_t crc2_length = 0;
+    static char *format = "IIn:crc32combine";
+    if (PyArg_ParseTuple(args, format, &crc1, &crc2, &crc2_length) < 0) {
+        return NULL;
+    }
+    return PyLong_FromUnsignedLong(
+        crc32_comb(crc1, crc2, crc2_length) & 0xFFFFFFFF);
+}
+
 PyDoc_STRVAR(zlib_compress__doc__,
 "compress($module, data, /, level=ISAL_DEFAULT_COMPRESSION, wbits=MAX_WBITS)\n"
 "--\n"
@@ -1186,39 +1220,6 @@ isal_zlib_Decompress_flush(decompobject *self, PyObject *const *args, Py_ssize_t
         return NULL;
     }
     return isal_zlib_Decompress_flush_impl(self, length);
-}
-
-PyDoc_STRVAR(isal_zlib_crc32_combine__doc__,
-"crc32_combine($module, crc1, crc2, crc2_length /)\n"
-"--\n"
-"\n"
-"Combine crc1 and crc2 into a new crc that is accurate for the combined data \n"
-"blocks that crc1 and crc2 where calculated from.\n"
-"\n"
-"  crc1\n"
-"    the first crc32 checksum\n"
-"  crc2\n"
-"    the second crc32 checksum\n"
-"  crc2_length\n"
-"    the lenght of the data block crc2 was calculated from\n"
-);
-
-
-#define ISAL_ZLIB_CRC32_COMBINE_METHODDEF    \
-    {"crc32_combine", (PyCFunction)(void(*)(void))isal_zlib_crc32_combine, \
-     METH_VARARGS, isal_zlib_crc32_combine__doc__}
-
-static PyObject *
-isal_zlib_crc32_combine(PyObject *module, PyObject *args) {
-    uint32_t crc1 = 0;
-    uint32_t crc2 = 0;
-    Py_ssize_t crc2_length = 0;
-    static char *format = "IIn:crc32combine";
-    if (PyArg_ParseTuple(args, format, &crc1, &crc2, &crc2_length) < 0) {
-        return NULL;
-    }
-    return PyLong_FromUnsignedLong(
-        crc32_comb(crc1, crc2, crc2_length) & 0xFFFFFFFF);
 }
 
 


### PR DESCRIPTION
### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)

- Make sure endianness is correct
- Allow arbitrarily large buffers. This is not important for python-isal, but for zlib with its uint16_MAX limitation this might prove a worthwhile fix. Also for zlib-ng.
- Move code in a more logical place.
- Make null byte skipper a bit more readable and logical