### PR TITLE
Update ISA-L to version 2.31.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Changelog
 
 version 1.6.0-dev
 -----------------
++ Update statically linked ISA-L release to 2.31.0
 + Fix an error that occurred in the ``__close__`` function when a threaded
   writer was initialized with incorrect parameters.
 

--- a/setup.py
+++ b/setup.py
@@ -33,15 +33,10 @@ BUILD_CACHE_FILE = Path(os.environ.get("PYTHON_ISAL_BUILD_CACHE_FILE",
                                        DEFAULT_CACHE_FILE))
 
 EXTENSIONS = [
-        Extension("isal.isal_zlib", ["src/isal/isal_zlibmodule.c"]),
-        Extension("isal.igzip_lib", ["src/isal/igzip_libmodule.c"]),
+    Extension("isal.isal_zlib", ["src/isal/isal_zlibmodule.c"]),
+    Extension("isal.igzip_lib", ["src/isal/igzip_libmodule.c"]),
+    Extension("isal._isal", ["src/isal/_isalmodule.c"]),
     ]
-
-# This does not add the extension on windows for dynamic linking. The required
-# header file might be missing.
-if not (SYSTEM_IS_WINDOWS and
-        os.getenv("PYTHON_ISAL_LINK_DYNAMIC") is not None):
-    EXTENSIONS.append(Extension("isal._isal", ["src/isal/_isalmodule.c"]))
 
 
 class BuildIsalExt(build_ext):

--- a/src/isal/__init__.py
+++ b/src/isal/__init__.py
@@ -5,19 +5,8 @@
 # This file is part of python-isal which is distributed under the
 # PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2.
 
-from typing import Optional
-
-try:
-    from . import _isal
-    ISAL_MAJOR_VERSION: Optional[int] = _isal.ISAL_MAJOR_VERSION
-    ISAL_MINOR_VERSION: Optional[int] = _isal.ISAL_MINOR_VERSION
-    ISAL_PATCH_VERSION: Optional[int] = _isal.ISAL_PATCH_VERSION
-    ISAL_VERSION: Optional[str] = _isal.ISAL_VERSION
-except ImportError:
-    ISAL_MAJOR_VERSION = None
-    ISAL_MINOR_VERSION = None
-    ISAL_PATCH_VERSION = None
-    ISAL_VERSION = None
+from ._isal import (ISAL_MAJOR_VERSION, ISAL_MINOR_VERSION, ISAL_PATCH_VERSION,
+                    ISAL_VERSION)
 
 __all__ = [
     "ISAL_MAJOR_VERSION",

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -11,7 +11,6 @@
 
 import gzip
 import itertools
-import os
 import zlib
 from pathlib import Path
 
@@ -34,8 +33,6 @@ SEEDS = [-INT_OVERFLOW, -3, -1, 0, 1, INT_OVERFLOW] + [
 
 # Wbits for ZLIB compression, GZIP compression, and RAW compressed streams
 WBITS_RANGE = list(range(9, 16)) + list(range(25, 32)) + list(range(-15, -8))
-
-DYNAMICALLY_LINKED = os.getenv("PYTHON_ISAL_LINK_DYNAMIC") is not None
 
 
 @pytest.mark.parametrize(["data_size", "value"],
@@ -93,8 +90,6 @@ def test_decompress_isal_zlib(data_size, level):
 @pytest.mark.parametrize(["data_size", "level", "wbits", "memLevel"],
                          itertools.product([128 * 1024], range(4),
                                            WBITS_RANGE, range(1, 10)))
-@pytest.mark.xfail(condition=DYNAMICALLY_LINKED,
-                   reason="Dynamically linked version may not have patch.")
 def test_compress_compressobj(data_size, level, wbits, memLevel):
     data = DATA[:data_size]
     compressobj = isal_zlib.compressobj(level=level,

--- a/tests/test_zlib_compliance.py
+++ b/tests/test_zlib_compliance.py
@@ -40,10 +40,6 @@ requires_Decompress_copy = unittest.skipUnless(
 
 
 class VersionTestCase(unittest.TestCase):
-
-    @unittest.skipIf(os.getenv("PYTHON_ISAL_LINK_DYNAMIC") is not None and
-                     sys.platform.startswith("win"),
-                     "Header file missing on windows")
     def test_library_version(self):
         # Test that the major version of the actual library in use matches the
         # major version that we were compiled against. We can't guarantee that


### PR DESCRIPTION
Since 2.31.0 is now available on conda, all the extra care to work around windows not creating isa-l.h can be deleted. 

### Checklist
- [x] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)
