### PR TITLE
Add macos-14 CI, which uses M1 architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
           - "pypy-3.10"
         os: ["ubuntu-latest"]
         include:
-          - os: "macos-latest"
+          - os: "macos-13"
+            python-version: 3.8
+          - os: "macos-14"
             python-version: 3.8
           - os: "windows-latest"
             python-version: 3.8
@@ -132,7 +134,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "macos-14", "windows-latest"]
         python_version: [ "python" ]
         include:
           - os: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-13", "macos-14", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python_version: [ "python" ]
         include:
           - os: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - develop
       - main
+      - macosCI
     tags:
       - "*"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13
+          - macos-14
           - windows-latest
         cibw_archs_linux: ["x86_64"]
         cibw_before_all_linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,11 @@ jobs:
         os: ["ubuntu-latest"]
         include:
           - os: "macos-13"
-            python-version: 3.8
+            python-version: "3.8"
           - os: "macos-14"
-            python-version: 3.8
+            python-version: "3.10"
           - os: "windows-latest"
-            python-version: 3.8
+            python-version: "3.8"
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - develop
       - main
-      - macosCI
     tags:
       - "*"
 


### PR DESCRIPTION
### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)

Updating after https://github.com/intel/isa-l/pull/278 merge.

Maybe the maintainer wants to wait for the next "release" of isa-l, but I put my CI result here so that some people can build their own python-isal build from the source code.

----

- Here github-action needs approval, but it passed on my fork action: https://github.com/cielavenir/python-isal-py2/actions/runs/8464068215
- My repository name is "-py2" as the main purpose is maintaining py2 port, but this pull request is surely for py3.