### PR TITLE
Automated versioning using versioningit.

### DIFF
--- a/.github/release_checklist.md
+++ b/.github/release_checklist.md
@@ -2,9 +2,7 @@ Release checklist
 - [ ] Check outstanding issues on JIRA and Github.
 - [ ] Check [latest documentation](https://python-isal.readthedocs.io/en/latest/) looks fine.
 - [ ] Create a release branch.
-  - [ ] Set version to a stable number.
   - [ ] Change current development version in `CHANGELOG.rst` to stable version.
-  - [ ] Change the version in `__init__.py`
 - [ ] Check if the address sanitizer does not find any problems using `tox -e asan`
 - [ ] Merge the release branch into `main`.
 - [ ] Created an annotated tag with the stable version number. Include changes 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Python 3.8
@@ -33,7 +33,7 @@ jobs:
           - twine_check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Python 3.8
@@ -71,7 +71,7 @@ jobs:
           - os: "windows-latest"
             python-version: "3.8"
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Python ${{ matrix.python-version }}
@@ -107,7 +107,7 @@ jobs:
         python_version:
           - "3.8"
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: uraimo/run-on-arch-action@v2.5.0
@@ -137,7 +137,7 @@ jobs:
           - os: "ubuntu-latest"
             python_version: "pypy"
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install miniconda.
@@ -186,9 +186,10 @@ jobs:
             cibw_archs_linux: "aarch64"
             cibw_before_all_linux: "true"  # The true command exits with 0
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0  # Fetch everything to get accurately versioned tag.
       - uses: actions/setup-python@v2
         name: Install Python
       - name: Install cibuildwheel twine wheel

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+src/isal/_version.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,8 @@
 graft src/isal/isa-l
 include src/isal/*.h
+prune tests
+prune docs
+prune benchmark_scripts
+exclude requirements-docs.txt
+exclude codecov.yml
+exclude .readthedocs.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.versioningit.vcs]
 method="git"
+default-tag = "v0.0.0"
 
 [tool.versioningit.write]
 file = "src/isal/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [build-system]
-requires = ["setuptools>=51", "wheel"]
+requires = ["setuptools>=64", "versioningit>=1.1.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.versioningit.vcs]
+method="git"
+
+[tool.versioningit.write]
+file = "src/isal/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
+import versioningit
+
 ISA_L_SOURCE = os.path.join("src", "isal", "isa-l")
 
 SYSTEM_IS_BSD = (sys.platform.startswith("freebsd") or
@@ -136,7 +138,7 @@ def build_isa_l():
 
 setup(
     name="isal",
-    version="1.7.0-dev",
+    version=versioningit.get_version(),
     description="Faster zlib and gzip compatible compression and "
                 "decompression by providing python bindings for the ISA-L "
                 "library.",

--- a/src/isal/_version.pyi
+++ b/src/isal/_version.pyi
@@ -5,14 +5,4 @@
 # This file is part of python-isal which is distributed under the
 # PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2.
 
-from ._isal import (ISAL_MAJOR_VERSION, ISAL_MINOR_VERSION, ISAL_PATCH_VERSION,
-                    ISAL_VERSION)
-from ._version import __version__
-
-__all__ = [
-    "ISAL_MAJOR_VERSION",
-    "ISAL_MINOR_VERSION",
-    "ISAL_PATCH_VERSION",
-    "ISAL_VERSION",
-    "__version__"
-]
+__version__: int


### PR DESCRIPTION
I do prefer using a more modern setup with a full pyproject.toml and setuptools_scm. 

Unfortunately, that messes up all the package includes in the wheel, shipping **the entire ISA-L source** in the **binary distribution**. The ISA-L source is needed for the source distribution though, so it cannot be excluded. (I tried several frustrating hours for this to work correctly).

So ``setup.py`` is the only option, and versioningit the only thing that caters to that option. It works well. I am actually quite happy with the minimal amount of code needed.

### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)
