### PR TITLE
BGZIP support

### DIFF
--- a/bgzip_runner.py
+++ b/bgzip_runner.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import io
+import sys
+
+from isal.igzip_threaded import _ThreadedGzipReader, _ThreadedBGzipReader
+
+def main():
+    file = sys.argv[1]
+    with io.BufferedReader(
+        _ThreadedBGzipReader(file, threads=8)
+    ) as f:
+        while True:
+            block = f.read(128 * 1024)
+            if block == b"":
+                return
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ EXTENSIONS = [
     Extension("isal.isal_zlib", ["src/isal/isal_zlibmodule.c"]),
     Extension("isal.igzip_lib", ["src/isal/igzip_libmodule.c"]),
     Extension("isal._isal", ["src/isal/_isalmodule.c"]),
+    Extension("isal._bgzip", ["src/isal/_bgzipmodule.c"]),
     ]
 
 

--- a/src/isal/_bgzip.pyi
+++ b/src/isal/_bgzip.pyi
@@ -1,0 +1,8 @@
+# Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+# 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
+# Python Software Foundation; All Rights Reserved
+
+# This file is part of python-isal which is distributed under the
+# PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2.
+
+def find_last_bgzip_end(__data: bytes) -> int: ...

--- a/src/isal/_bgzipmodule.c
+++ b/src/isal/_bgzipmodule.c
@@ -12,14 +12,97 @@ for this one file seemed silly.
 */
 
 #define PY_SSIZE_T_CLEAN
-#include "Python.h"
+#include <Python.h>
+#include <stdbool.h>
+
+#define FEXTRA 4
+
+static inline uint16_t load_u16_le(const void *address) {
+    #if PY_BIG_ENDIAN
+    uint8_t *mem = address;
+    return mem[0] | (mem[1] << 8);
+    #else
+    return *(uint16_t *)address;
+    #endif
+}
+
+static PyObject *find_last_bgzip_end(PyObject *module, PyObject *buffer_obj) {
+    Py_buffer buf; 
+    int ret = PyObject_GetBuffer(buffer_obj, &buf, PyBUF_SIMPLE);
+    if (ret == -1) {
+        return NULL;
+    }
+    const uint8_t *data = buf.buf;
+    Py_ssize_t data_length = buf.len;
+    const uint8_t *data_end = data + data_length;
+    const uint8_t *cursor = data;
+
+    Py_ssize_t answer = 0;
+    while (true) {
+        if (data_end - cursor < 18) {
+            break;
+        }
+        uint8_t magic1 = cursor[0];
+        uint8_t magic2 = cursor[1];
+        if (magic1 != 31 || magic2 != 139) {
+            PyErr_Format(PyExc_ValueError, 
+            "Incorrect gzip magic: %x, %x", magic1, magic2);
+            return NULL;
+        }
+        uint8_t method = cursor[2];
+        if (method != 8) {
+            PyErr_Format(
+                PyExc_ValueError,
+                "Incorrect method: %x", method
+            );
+            return NULL;
+        }
+        uint8_t flags = cursor[3];
+        if (flags != FEXTRA) {
+            PyErr_SetString(
+                PyExc_NotImplementedError,
+                "Only bgzip files with only FEXTRA flag set are supported."
+            );
+            return NULL;
+        }
+        uint16_t xlen = load_u16_le(cursor + 10);
+        if (xlen != 6) {
+            PyErr_SetString(
+                PyExc_NotImplementedError,
+                "Only bgzip files with one extra field are supported."
+            );
+            return NULL;
+        }
+        uint8_t si1 = cursor[12];
+        uint8_t si2 = cursor[13];
+        uint16_t subfield_length = load_u16_le(cursor + 14);
+        if (si1 != 66 || si2 != 67 || subfield_length != 2) {
+            PyErr_Format(
+                PyExc_ValueError,
+                "Incorrectly formatted magic and subfield length, "
+                "expected 66, 67, 2 got %d, %d, %d", 
+                si1, si2, subfield_length
+            );
+            return NULL;
+        }
+        uint16_t block_size = load_u16_le(cursor + 16);
+        size_t actual_block_size = block_size + 1;
+        cursor += actual_block_size;
+    }
+    return PyLong_FromSsize_t(answer);
+}
+
+static PyMethodDef _bgzip_methods[] = {
+    {"find_last_bgzip_end", find_last_bgzip_end, METH_O, NULL},
+    {NULL},
+};
 
 static struct PyModuleDef _bgzip_module = {
     PyModuleDef_HEAD_INIT,
-    "_bgzip",   /* name of module */
-    NULL, /* module documentation, may be NULL */
-    -1,
-    NULL,
+    .m_name = "_bgzip",
+    .m_doc = NULL,
+    .m_size = -1,
+    .m_methods = _bgzip_methods,
 };
 
 PyMODINIT_FUNC

--- a/src/isal/_bgzipmodule.c
+++ b/src/isal/_bgzipmodule.c
@@ -1,0 +1,33 @@
+/*
+Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022
+Python Software Foundation; All Rights Reserved
+
+This file is part of python-isal which is distributed under the
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2.
+
+This file is not originally from the CPython distribution. But it does
+contain mostly example code from the Python docs. Also dual licensing just
+for this one file seemed silly.
+*/
+
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
+static struct PyModuleDef _bgzip_module = {
+    PyModuleDef_HEAD_INIT,
+    "_bgzip",   /* name of module */
+    NULL, /* module documentation, may be NULL */
+    -1,
+    NULL,
+};
+
+PyMODINIT_FUNC
+PyInit__bgzip(void)
+{
+    PyObject *m = PyModule_Create(&_bgzip_module);
+    if (m == NULL) {
+        return NULL;
+    }
+    return m;
+}

--- a/src/isal/_bgzipmodule.c
+++ b/src/isal/_bgzipmodule.c
@@ -44,44 +44,32 @@ static PyObject *find_last_bgzip_end(PyObject *module, PyObject *buffer_obj) {
         }
         uint8_t magic1 = cursor[0];
         uint8_t magic2 = cursor[1];
-        if (magic1 != 31 || magic2 != 139) {
-            PyErr_Format(PyExc_ValueError, 
-            "Incorrect gzip magic: %x, %x", magic1, magic2);
-            return NULL;
-        }
         uint8_t method = cursor[2];
-        if (method != 8) {
-            PyErr_Format(
-                PyExc_ValueError,
-                "Incorrect method: %x", method
-            );
-            return NULL;
-        }
         uint8_t flags = cursor[3];
-        if (flags != FEXTRA) {
-            PyErr_SetString(
-                PyExc_NotImplementedError,
-                "Only bgzip files with only FEXTRA flag set are supported."
-            );
-            return NULL;
-        }
         uint16_t xlen = load_u16_le(cursor + 10);
-        if (xlen != 6) {
-            PyErr_SetString(
-                PyExc_NotImplementedError,
-                "Only bgzip files with one extra field are supported."
-            );
-            return NULL;
-        }
         uint8_t si1 = cursor[12];
         uint8_t si2 = cursor[13];
-        uint16_t subfield_length = load_u16_le(cursor + 14);
-        if (si1 != 66 || si2 != 67 || subfield_length != 2) {
+        uint16_t subfield_length = load_u16_le(cursor + 14);        
+        if (
+            magic1 != 31 || 
+            magic2 != 139 ||
+            method != 8 ||
+            flags != FEXTRA ||
+            xlen != 6 ||
+            si1 != 66 ||
+            si2 != 67 ||
+            subfield_length != 2
+        ) {
             PyErr_Format(
-                PyExc_ValueError,
-                "Incorrectly formatted magic and subfield length, "
-                "expected 66, 67, 2 got %d, %d, %d", 
-                si1, si2, subfield_length
+                PyExc_ValueError, 
+                "Incorrect bgzip header:\n"
+                "magic: %x, %x\n" 
+                "method: %x\n"  
+                "flags: %x\n"
+                "xlen: %d\n"
+                "si1, si2: %d, %d \n"
+                "subfield_length: %d",
+                magic1, magic2, method, flags, xlen, si1, si2, subfield_length
             );
             return NULL;
         }

--- a/src/isal/igzip_threaded.py
+++ b/src/isal/igzip_threaded.py
@@ -168,9 +168,14 @@ class _ThreadedGzipReader(io.RawIOBase):
 
 
 class _ThreadedBGzipReader(io.RawIOBase):
-    def __init__(self, filename, threads=2, queue_size=2, block_size=1024 * 1024):
-        if threads < 2:
-            raise RuntimeError("_ThreadedGzipReader class handles that use case.")
+    """
+    Reads BGZip files multithreaded. For one thread, the normal gzip reader
+    class is more efficient, as it operates fewer queues and keeps less
+    allocated data around.
+    """
+    def __init__(self, filename, threads=1, queue_size=2, block_size=1024 * 1024):
+        if threads < 1:
+            raise RuntimeError("At least one thread is needed")
         self.raw, self.closefd = open_as_binary_stream(filename, "rb")
 
         self.lock = threading.Lock()

--- a/src/isal/igzip_threaded.py
+++ b/src/isal/igzip_threaded.py
@@ -252,18 +252,6 @@ class _ThreadedBGzipReader(io.RawIOBase):
                 except queue.Full:
                     pass
 
-    def _set_error_and_empty_queue(self, error, q):
-        with self.lock:
-            self.exception = error
-            # Abort everything and empty the queue
-            self.running = False
-            while True:
-                try:
-                    _ = q.get(timeout=0.05)
-                    q.task_done()
-                except queue.Empty:
-                    return
-
     def readinto(self, b):
         self._check_closed()
         result = self.buffer.readinto(b)


### PR DESCRIPTION
### Checklist
- [ ] Pull request details were added to CHANGELOG.rst
- [ ] Documentation was updated (if needed)

@marcelm I noticed Sequali was bottlenecked by the gzip decompression. On the latest develop branch, analysing ONT files is faster than decompressing them. On BAM formats however this can be theoretically circumvented beacuse all BGZIP blocks are independent. FASTQ files are also often bgzip compressed. So I set out to write some code to alleviate this.

It works. Question is how to integrate this properly into xopen. My thoughts on this are

- Create a separate bgzip module here (`isal.bgzip`). 
- Create a bgzip.open function. One threaded opening is moved off to the single-threaded opener in `isal.igzip_threaded` as there is less overhead involved.
- More threads are moved off to the _ThreadedBgzipReader class 
- In `xopen` detect the bgzip format by parsing the gzip header and use bgzip.open if that is the case. 
- I have no plans to support writing yet, but that could be useful if dnaio supports uBAM writing in the future. I will leave that job for when I need it though.
 
What are your thoughts on this?