### PR TITLE
Mark extensions as free-threading-compatible and build wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.13t"
           - "pypy-3.9"
           - "pypy-3.10"
         os: ["ubuntu-latest"]
@@ -215,6 +216,7 @@ jobs:
         run: cibuildwheel --output-dir dist
         env:
           CIBW_SKIP: "*-win32 *-manylinux_i686 cp38-macosx_*arm64 cp39-macosx_*arm64"  # Skip 32 bit and problematic mac builds.
+          CIBW_ENABLE: "cpython-freethreading"
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
           CIBW_BEFORE_ALL_LINUX: ${{ matrix.cibw_before_all_linux }}
           # Fully test the build wheels again.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ version 1.8.0-dev
 + Include test packages in the source distribution, so source distribution
   installations can be verified.
 + Fix an issue where some tests failed because they ignored PYTHONPATH.
++ Enable support for free-threading and build free-threaded wheels for
+  CPython 3.13.
 
 version 1.7.2
 -----------------

--- a/src/isal/_isalmodule.c
+++ b/src/isal/_isalmodule.c
@@ -31,6 +31,11 @@ PyInit__isal(void)
     if (m == NULL) {
         return NULL;
     }
+
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     PyModule_AddIntMacro(m, ISAL_MAJOR_VERSION);
     PyModule_AddIntMacro(m, ISAL_MINOR_VERSION);
     PyModule_AddIntMacro(m, ISAL_PATCH_VERSION);

--- a/src/isal/igzip_libmodule.c
+++ b/src/isal/igzip_libmodule.c
@@ -617,6 +617,11 @@ PyInit_igzip_lib(void)
     if (m == NULL)
         return NULL;
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
+
     IsalError = PyErr_NewException("igzip_lib.IsalError", NULL, NULL);
     if (IsalError == NULL) {
         return NULL;

--- a/src/isal/isal_zlibmodule.c
+++ b/src/isal/isal_zlibmodule.c
@@ -2183,6 +2183,10 @@ PyInit_isal_zlib(void)
         return NULL;
     }
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
     PyObject *igzip_lib_module = PyImport_ImportModule("isal.igzip_lib");
     if (igzip_lib_module == NULL) {
         return NULL;


### PR DESCRIPTION
### Checklist
- [X] Pull request details were added to CHANGELOG.rst
- [X] Documentation was updated (if needed)

Hi there! 👋

I'm opening this PR to implement support for the free-threaded build. I checked that there's no global state and you're locking when compressor/decompressor objects are shared, so we should be good to go. Hopefully this helps. Let me know if I can help any other way!