### PR TITLE
ci: re-enable PyPy wheel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
       - name: Build wheels
         run: cibuildwheel --output-dir dist
         env:
+          CIBW_ENABLE: "pypy"
           CIBW_SKIP: "*-win32 *-manylinux_i686 cp38-macosx_*arm64 cp39-macosx_*arm64"  # Skip 32 bit and problematic mac builds.
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
           CIBW_BEFORE_ALL_LINUX: ${{ matrix.cibw_before_all_linux }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Changelog
 .. that users understand how the changes affect the new version.
 
 
+version 1.8.1-dev
+-----------------
++ Restore PyPy wheel builds.
+
 version 1.8.0
 -----------------
 + Python 3.14 is supported.


### PR DESCRIPTION
Hey @rhpvorderman - quick patch to close #245.

Let me know if you'd like to make the jump to the `cibuildwheel` action suggested in that issue now or in a follow-up PR. 

